### PR TITLE
Fix API URL to remove localhost reference

### DIFF
--- a/react-app/src/Main.js
+++ b/react-app/src/Main.js
@@ -14,7 +14,7 @@ function Main() {
   const [services, setServices] = useState({});
 
   async function fetchData() {
-    const res = await fetch('http://localhost:8080/api/services');
+    const res = await fetch('/api/services');
     res
       .json()
       .then(res => setServices(res.services))


### PR DESCRIPTION
With a `proxy` set in `./react-app/package.json`, this updated API URL reference should work in production on Heroku.