### PR TITLE
Add IE11 polyfill

### DIFF
--- a/react-app/package.json
+++ b/react-app/package.json
@@ -9,6 +9,7 @@
     "@testing-library/user-event": "^7.2.1",
     "node-sass": "^4.14.1",
     "react": "^16.13.1",
+    "react-app-polyfill": "^1.0.6",
     "react-dom": "^16.13.1",
     "react-highlight-words": "^0.16.0",
     "react-responsive": "^8.1.0",

--- a/react-app/src/index.js
+++ b/react-app/src/index.js
@@ -1,3 +1,5 @@
+import "react-app-polyfill/ie11";
+import "react-app-polyfill/stable";
 import React from "react";
 import ReactDOM from "react-dom";
 import "./index.scss";


### PR DESCRIPTION
- Adds `react-app-polyfill` as a dependency
- Imports IE11 and `stable` polyfills in front-end `index.js`