### PR TITLE
Turn off autocomplete and prevent default behavior of Header search form

### DIFF
--- a/react-app/src/stories/SearchBar.js
+++ b/react-app/src/stories/SearchBar.js
@@ -3,7 +3,13 @@ import React from "react";
 import "./searchbar.css";
 
 export const SearchBar = () => (
-  <form className="search">
+  <form
+    className="search"
+    autocomplete="off"
+    onSubmit={(e) => {
+      e.preventDefault();
+    }}
+  >
     <input type="search" aria-label="Search" />
     <button className="button--search" type="submit" />
   </form>


### PR DESCRIPTION
Remove autocomplete and `preventDefault()` in Header search bar